### PR TITLE
Fix the issue of download script always trying to download

### DIFF
--- a/data4robotics/load_pretrained.py
+++ b/data4robotics/load_pretrained.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import os, torch, data4robotics
+import os, torch, subprocess, data4robotics
 from torchvision import transforms
 from data4robotics.models import vit
 from data4robotics.models import resnet
@@ -16,8 +16,8 @@ FEATURE_PATH = os.path.join(BASE_PATH, "visual_features")
 
 
 def _check_and_download():
-    download_script = os.path.join(BASE_PATH, 'download_features.sh')
-    os.system(download_script)
+    download_script = os.path.join(BASE_PATH, "download_features.sh")
+    subprocess.run([download_script, BASE_PATH], check=True)
 
 
 def default_transform():

--- a/download_features.sh
+++ b/download_features.sh
@@ -1,12 +1,26 @@
 #!/usr/bin/env bash
 
-# make sure the folder doesn't already exist
-if [ -d "visual_features" ]; then
-    echo "Data already downloaded!"
-    exit 0
+# Optional default path as the first argument
+DEFAULT_PATH=$1
+
+# Function to check if the directory exists
+check_directory() {
+    if [ -d "$1" ]; then
+        echo "Data already downloaded in $1!"
+        exit 0
+    fi
+}
+
+# Check if the default path is provided and valid
+if [ -n "$DEFAULT_PATH" ]; then
+    # Check in the default path
+    check_directory "${DEFAULT_PATH}/visual_features"
+else
+    # Check as-is
+    check_directory "visual_features"
 fi
 
+# Download and extract process
 wget --output-document features.zip https://cmu.box.com/shared/static/rrlrp5g6ynk03io4rj9uzf6nik5urfl6
 unzip features.zip
 rm features.zip
-


### PR DESCRIPTION
This PR fixes the issue of download script always trying to download the pre-trained weights in an active python workspace directory (e.g., when you want to load the pre-trained parameters in outside project directory via load_vit or load_resnet18)

Congrats on the nice work and hope this helps.